### PR TITLE
Apply postcss-html to XML and XSLT files

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,13 @@ const defaultConfig = {
 			lang: "css",
 		},
 		{
-			test: /\.(?:[sx]?html?|xml|xslt?|[sx]ht|vue|ux|markdown|md|php)$/i,
+			// *.xslt?	https://msdn.microsoft.com/en-us/library/ms764661(v=vs.85).aspx
+			// *.vue	https://vue-loader.vuejs.org/spec.html
+			// *.ux		https://doc.quickapp.cn/framework/source-file.html
+			// `*.xml`	Just for fault tolerance, XML is not supported except XSLT
+			// `*.htm`, `*.*htm`
+			// `*.html`, `*.*html`
+			test: /\.(?:\w*html?|x(?:ht|ml|slt?)|markdown|md|php|vue|ux)$/i,
 			extract: "html",
 		},
 		{

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const defaultConfig = {
 			lang: "css",
 		},
 		{
-			test: /\.(?:[sx]?html?|[sx]ht|vue|ux|markdown|md|php)$/i,
+			test: /\.(?:[sx]?html?|xml|xslt?|[sx]ht|vue|ux|markdown|md|php)$/i,
 			extract: "html",
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-syntax",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Automatically switch PostCSS syntax by file extensions",
   "repository": {
     "type": "git",
@@ -39,10 +39,10 @@
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",
     "postcss": "^6.0.22",
-    "postcss-html": ">=0.27.0",
-    "postcss-jsx": ">=0.27.0",
+    "postcss-html": ">=0.28.0",
+    "postcss-jsx": ">=0.28.0",
     "postcss-less": "^2.0.0",
-    "postcss-markdown": ">=0.27.0",
+    "postcss-markdown": ">=0.28.0",
     "postcss-safe-parser": "^3.0.1",
     "postcss-scss": "^1.0.5",
     "sugarss": "^1.0.1"

--- a/test/rules.js
+++ b/test/rules.js
@@ -52,11 +52,30 @@ describe("default config rules", () => {
 	it("foo.htm", () => {
 		expect(getRule("foo.htm")).to.haveOwnProperty("extract", "html");
 	});
+	it("foo.shtml", () => {
+		expect(getRule("foo.shtml")).to.haveOwnProperty("extract", "html");
+	});
 	it("foo.xht", () => {
 		expect(getRule("foo.xht")).to.haveOwnProperty("extract", "html");
 	});
-	it("foo.shtml", () => {
-		expect(getRule("foo.shtml")).to.haveOwnProperty("extract", "html");
+	it("foo.xhtml", () => {
+		expect(getRule("foo.xhtml")).to.haveOwnProperty("extract", "html");
+	});
+	it("foo.xml", () => {
+		// Just for fault tolerance, XML is not supported except XSLT
+		expect(getRule("foo.xml")).to.haveOwnProperty("extract", "html");
+	});
+	it("foo.xsl", () => {
+		expect(getRule("foo.xsl")).to.haveOwnProperty("extract", "html");
+	});
+	it("foo.xslt", () => {
+		expect(getRule("foo.xslt")).to.haveOwnProperty("extract", "html");
+	});
+	it("foo.vue", () => {
+		expect(getRule("foo.vue")).to.haveOwnProperty("extract", "html");
+	});
+	it("foo.ux", () => {
+		expect(getRule("foo.ux")).to.haveOwnProperty("extract", "html");
 	});
 	it("foo.php", () => {
 		expect(getRule("foo.php")).to.haveOwnProperty("extract", "html");


### PR DESCRIPTION
Because a file with one of those extensions may contain `<STYLE>` tags in its body. https://msdn.microsoft.com/en-us/library/ms764661(v=vs.85).aspx

This is an actual fix for https://github.com/stylelint/stylelint/issues/3328.
