### PR TITLE
support export statement syntax in js

### DIFF
--- a/get-lang.js
+++ b/get-lang.js
@@ -49,7 +49,7 @@ function sourceType (source) {
 		// start with strict mode
 		// start with import code
 		// start with require code
-		/^(?:(?:\/\/[^\r\n]*\r?\n|\/\*.*?\*\/)\s*)*(?:(?:("|')use strict\1|import(?:\s+[^;]+\s+from)?\s+("|')[^'"]+?\2)\s*(;|\r?\n|$)|(?:(?:var|let|const)\s+[^;]+\s*=\s*)?(?:require|import)\(.+\))/.test(source) ||
+		/^(?:(?:\/\/[^\r\n]*\r?\n|\/\*.*?\*\/)\s*)*(?:(?:("|')use strict\1|import(?:\s+[^;]+\s+from)?\s+("|')[^'"]+?\2|export\s+[^;]+\s+[^;]+)\s*(;|\r?\n|$)|(?:(?:var|let|const)\s+[^;]+\s*=\s*)?(?:require|import)\(.+\))/.test(source) ||
 		// https://en.wikipedia.org/wiki/Shebang_(Unix)
 		(/^#!([^\r\n]+)/.test(source) && /(?:^|\s+|\/)(?:ts-)?node(?:\.\w+)?(?:\s+|$)$/.test(RegExp.$1))
 	) {

--- a/test/languages.js
+++ b/test/languages.js
@@ -167,6 +167,24 @@ describe("language tests", () => {
 		"var a=require('a');",
 		"import(\"a\");",
 		"const a = import('a');",
+		// https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export
+		// https://github.com/tc39/proposal-export-default-from
+		// https://www.npmjs.com/package/babel-plugin-transform-export-extensions
+		"export var v;",
+		"export default function f(){}",
+		"export default function(){}",
+		"export default class {}",
+		"export default 42;",
+		"export defaultExport from \"module-name\";",
+		"export { named };",
+		"export { named as alias };",
+		"export { named } from \"module-name\";",
+		"export { named as alias } from \"module-name\";",
+		"export { named1, namedExport2 } from \"module-name\";",
+		"export { named1, named2 as alias2, [...] } from \"module-name\";",
+		"export * from \"module-name\"",
+		"export * as defaultExport from \"module-name\"",
+		"export defaultExport, { named1, named2 as alias2 } from \"module-name\";"
 	]);
 
 	testcase("css", [


### PR DESCRIPTION
support for code like 
https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export

```js
export { name1, name2, …, nameN };
```