### PR TITLE
Move syntax modules into main dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,13 +91,15 @@
     "mocha": "^5.2.0",
     "nyc": "^13.1.0",
     "postcss": "^7.0.7",
+    "postcss-safe-parser": "^4.0.1",
+    "proxyquire": "^2.1.0",
+    "sugarss": "^2.0.0"
+  },
+  "dependencies": {
     "postcss-html": ">=0.36.0",
     "postcss-jsx": ">=0.36.0",
     "postcss-less": "^3.1.0",
     "postcss-markdown": ">=0.36.0",
-    "postcss-safe-parser": "^4.0.1",
-    "postcss-scss": "^2.0.0",
-    "proxyquire": "^2.1.0",
-    "sugarss": "^2.0.0"
+    "postcss-scss": "^2.0.0"
   }
 }


### PR DESCRIPTION
This change moves the various PostCSS syntax modules from the package's `devDependencies` into its `dependencies`. Since the modules are required at runtime, it's appropriate to include them in the main dependencies. Additionally, the current pattern makes it difficult to use this package with the updated version of Yarn, which enforces boundaries between dependencies more diligently and [throws errors](https://next.yarnpkg.com/advanced/migration#a-package-is-trying-to-access-another-package-) when `require`-ing implicit dependencies.